### PR TITLE
Avoid link injection even when the URL has extra dot or slash 

### DIFF
--- a/examples/with-components/with-components.spec.js
+++ b/examples/with-components/with-components.spec.js
@@ -29,7 +29,7 @@ describe('examples/with-components', () => {
 
     it('should add main stylesheet link to head', () => {
       expect($('link[rel="stylesheet"]').attr('href')).toBe(
-        'bundled-css/main.abell.css'.replace(/\//g, path.sep)
+        'bundled-css/main.abell.css'
       );
     });
 
@@ -48,7 +48,7 @@ describe('examples/with-components', () => {
 
     it('should add main stylesheet link to head', () => {
       expect($('link[rel="stylesheet"]').attr('href')).toBe(
-        '../bundled-css/main.abell.css'.replace(/\//g, path.sep)
+        '../bundled-css/main.abell.css'
       );
     });
 

--- a/examples/with-minimal-components/theme/index.abell
+++ b/examples/with-minimal-components/theme/index.abell
@@ -3,7 +3,7 @@
 }}
 <html>
 <head>
-  <link rel="preload" href="bundled-css/main.abell.css" onload="this.rel='stylesheet'; this.onload=null"/>
+  <link rel="preload" href="./bundled-css/main.abell.css" onload="this.rel='stylesheet'; this.onload=null"/>
   <title>Minimal Component Example</title>
 </head>
 <body>

--- a/examples/with-minimal-components/with-minimal-components.spec.js
+++ b/examples/with-minimal-components/with-minimal-components.spec.js
@@ -18,9 +18,7 @@ describe('examples/with-components', () => {
       );
     });
     it('should have default script import injected by abell', () => {
-      expect(indexHTML).toContain(
-        `<script src="bundled-js${path.sep}nav.js"></script>`
-      );
+      expect(indexHTML).toContain(`<script src="bundled-js/nav.js"></script>`);
     });
 
     it('should have custom style tag and not default tag', () => {
@@ -29,7 +27,7 @@ describe('examples/with-components', () => {
       );
 
       expect(indexHTML).not.toContain(
-        `<link rel="stylesheet" href="bundled-css${path.sep}main.abell.css"/>`
+        `<link rel="stylesheet" href="bundled-css/main.abell.css"/>`
       );
     });
   });

--- a/examples/with-minimal-components/with-minimal-components.spec.js
+++ b/examples/with-minimal-components/with-minimal-components.spec.js
@@ -10,14 +10,26 @@ describe('examples/with-components', () => {
   });
 
   describe('index.html', () => {
-    it('should have default script import injected by abell', () => {
-      const indexHTML = fs.readFileSync(
+    let indexHTML;
+    beforeAll(() => {
+      indexHTML = fs.readFileSync(
         path.join(__dirname, 'dist', 'index.html'),
         'utf-8'
       );
-
+    });
+    it('should have default script import injected by abell', () => {
       expect(indexHTML).toContain(
         `<script src="bundled-js${path.sep}nav.js"></script>`
+      );
+    });
+
+    it('should have custom style tag and not default tag', () => {
+      expect(indexHTML).toContain(
+        `<link rel="preload" href="./bundled-css/main.abell.css" onload="this.rel='stylesheet'; this.onload=null"/>`
+      );
+
+      expect(indexHTML).not.toContain(
+        `<link rel="stylesheet" href="bundled-css${path.sep}main.abell.css"/>`
       );
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "abell",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "abell-renderer": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abell",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Abell is a static blog generator that generates blog in Vanilla JavaScript",
   "funding": {
     "type": "patreon",

--- a/src/utils/abell-bundler.js
+++ b/src/utils/abell-bundler.js
@@ -195,15 +195,20 @@ function createBundles({ htmlOut, outPath, components, programInfo }) {
       addedLinks.push(bundle.path);
 
       if (
-        new RegExp(`<link.*?href=["'].?/?${bundle.path}["']`, 'g').test(htmlOut)
+        new RegExp(
+          `<link.*?href=["'].?/?${bundle.path.replace(/\\/g, '/')}["']`,
+          'g'
+        ).test(htmlOut)
       ) {
         return '';
       }
 
-      return `\n<link rel="stylesheet" href="${path.relative(
-        path.dirname(outPath),
-        path.join(programInfo.abellConfig.outputPath, bundle.path)
-      )}"/>\n`;
+      return `\n<link rel="stylesheet" href="${path
+        .relative(
+          path.dirname(outPath),
+          path.join(programInfo.abellConfig.outputPath, bundle.path)
+        )
+        .replace(/\\/g, '/')}"/>\n`;
     });
 
   const jsLinks = Object.values(bundleMap)
@@ -216,17 +221,20 @@ function createBundles({ htmlOut, outPath, components, programInfo }) {
       addedLinks.push(bundle.path);
 
       if (
-        new RegExp(`<script.*?src=["'].?/?${bundle.path}["']`, 'g').test(
-          htmlOut
-        )
+        new RegExp(
+          `<script.*?src=["'].?/?${bundle.path.replace(/\\/g, '/')}["']`,
+          'g'
+        ).test(htmlOut)
       ) {
         return '';
       }
 
-      return `\n<script src="${path.relative(
-        path.dirname(outPath),
-        path.join(programInfo.abellConfig.outputPath, bundle.path)
-      )}"></script>\n`;
+      return `\n<script src="${path
+        .relative(
+          path.dirname(outPath),
+          path.join(programInfo.abellConfig.outputPath, bundle.path)
+        )
+        .replace(/\\/g, '')}"></script>\n`;
     });
 
   htmlOut = addToBodyEnd(jsLinks.join('\n'), htmlOut);

--- a/src/utils/abell-bundler.js
+++ b/src/utils/abell-bundler.js
@@ -195,7 +195,7 @@ function createBundles({ htmlOut, outPath, components, programInfo }) {
       addedLinks.push(bundle.path);
 
       if (
-        new RegExp(`<link.*?href=["']${bundle.path}["']`, 'g').test(htmlOut)
+        new RegExp(`<link.*?href=["'].?/?${bundle.path}["']`, 'g').test(htmlOut)
       ) {
         return '';
       }
@@ -216,7 +216,9 @@ function createBundles({ htmlOut, outPath, components, programInfo }) {
       addedLinks.push(bundle.path);
 
       if (
-        new RegExp(`<script.*?src=["']${bundle.path}["']`, 'g').test(htmlOut)
+        new RegExp(`<script.*?src=["'].?/?${bundle.path}["']`, 'g').test(
+          htmlOut
+        )
       ) {
         return '';
       }

--- a/src/utils/abell-bundler.js
+++ b/src/utils/abell-bundler.js
@@ -234,7 +234,7 @@ function createBundles({ htmlOut, outPath, components, programInfo }) {
           path.dirname(outPath),
           path.join(programInfo.abellConfig.outputPath, bundle.path)
         )
-        .replace(/\\/g, '')}"></script>\n`;
+        .replace(/\\/g, '/')}"></script>\n`;
     });
 
   htmlOut = addToBodyEnd(jsLinks.join('\n'), htmlOut);


### PR DESCRIPTION
<!---
To check the checkbox add 'x' inside brackets
E.g:
- [x] Feature
-->

## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

## Description

Fixes #119 

Link injection now handles cases like `./bundled-js/main.abell.js`, `/bundled-js/main.abell.js`, `bundled-js/main.abell.js`

## Added unit tests?

- [ ] No, I want help in writing tests.
- [ ] No, I want someone else to write tests.
- [ ] No, The addition does not need tests.
- [x] Yes

## [optional] Random GIF to +1 someone's day
