### PR TITLE
perf(abell): reduce number of HTML transformation in build

### DIFF
--- a/packages/abell/package.json
+++ b/packages/abell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abell",
-  "version": "1.0.0-alpha.108",
+  "version": "1.0.0-alpha.110",
   "description": "Abell is a static-site-generator for JavaScript developers. Powered by Vite, It tries to stay close to fundamentals while providing a great DX",
   "bin": "./dist/bin.js",
   "main": "./dist/index.js",

--- a/packages/abell/package.json
+++ b/packages/abell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abell",
-  "version": "1.0.0-alpha.106",
+  "version": "1.0.0-alpha.108",
   "description": "Abell is a static-site-generator for JavaScript developers. Powered by Vite, It tries to stay close to fundamentals while providing a great DX",
   "bin": "./dist/bin.js",
   "main": "./dist/index.js",

--- a/packages/abell/src/cli/generate.ts
+++ b/packages/abell/src/cli/generate.ts
@@ -5,11 +5,38 @@ import { build as viteBuild } from 'vite';
 import {
   getConfigPath,
   getViteBuildInfo,
-  createPathIfAbsent
+  createPathIfAbsent,
+  addCSSToHead,
+  addJStoBodyEnd
 } from '../utils/internal-utils.js';
 
 import { Route } from '../type-utils';
 import { bold, log, viteCustomLogger } from '../utils/logger.js';
+import { generateHashFromPath } from '../vite-plugin-abell/compiler/scope-css/generate-hash.js';
+
+const CSS_FETCH_REGEX = /<link.*?href="(.*?)".*?\/?>/g;
+const JS_FETCH_REGEX = /<script src="(.*?)">/g;
+
+const getTemplateEntryInfo = (
+  appHtml: string
+): {
+  templateEntry: string;
+  templateEntryHash: string;
+} => {
+  const newTemplateEntry = [
+    ...Array.from(appHtml?.matchAll(CSS_FETCH_REGEX)),
+    ...Array.from(appHtml.matchAll(JS_FETCH_REGEX))
+  ]
+    .map((linkMatch) => linkMatch[0])
+    .join('\n');
+
+  const newTemplateEntryHash = generateHashFromPath(newTemplateEntry);
+
+  return {
+    templateEntry: newTemplateEntry,
+    templateEntryHash: newTemplateEntryHash
+  };
+};
 
 async function generate(): Promise<void> {
   const cwd = process.cwd();
@@ -67,50 +94,124 @@ async function generate(): Promise<void> {
   }
 
   // Generate index.html
-  const createdHTMLFiles = [];
-  const createdDirectories = [];
+  const createdHTMLFiles: string[] = [];
+  const transformationSkippedHTMLFiles = [];
+  const createdDirectories: string[] = [];
+  const memoizedTemplates: Record<string, { htmlPath: string }> = {};
+  // let hasTransformedTwice = false;
 
-  for (const route of routes) {
-    const appHtml = route.render();
-    if (!appHtml) continue;
-    let htmlPath = path.join(
-      ROOT,
-      `${route.path === '/' ? 'index' : route.path}.html`
-    );
-    if (route.routeOptions?.outputPathPattern === '[route]/index.html') {
-      htmlPath = path.join(ROOT, route.path, 'index.html');
-    }
+  const createHTMLForTransformation = (
+    htmlPath: string,
+    appHtml: string
+  ): void => {
     const newDirs = createPathIfAbsent(path.dirname(htmlPath));
     createdDirectories.push(...newDirs);
     fs.writeFileSync(htmlPath, appHtml);
     createdHTMLFiles.push(htmlPath);
-  }
+  };
 
-  // Static build
-  await viteBuild({
-    build: {
-      outDir: OUTPUT_DIR,
-      emptyOutDir: true,
-      rollupOptions: {
-        input: createdHTMLFiles
+  try {
+    for (const route of routes) {
+      const appHtml = route.render();
+      if (!appHtml) continue;
+
+      let htmlPath = path.join(
+        ROOT,
+        `${route.path === '/' ? 'index' : route.path}.html`
+      );
+      if (route.routeOptions?.outputPathPattern === '[route]/index.html') {
+        htmlPath = path.join(ROOT, route.path, 'index.html');
       }
-    },
-    customLogger: viteCustomLogger,
-    configFile
-  });
 
-  for (const HTML_FILE of createdHTMLFiles) {
-    fs.unlinkSync(HTML_FILE);
+      const { templateEntry, templateEntryHash } =
+        getTemplateEntryInfo(appHtml);
+
+      if (templateEntry && memoizedTemplates[templateEntryHash]) {
+        // if (hasTransformedTwice) {
+        console.log('Skip transforms');
+        transformationSkippedHTMLFiles.push({
+          templateEntryHash,
+          htmlPath,
+          appHtml
+        });
+        // } else {
+        //   // We run 1 extra transformation on same template even if its memoized earlier
+        //   // Rollup by default renames file to HTML's name when its only used once.
+        //   // Running transformation over 2 templates keeps the css name consistent for us to eventually map
+        //   console.log('We transform');
+        //   hasTransformedTwice = true;
+        //   createHTMLForTransformation(htmlPath, appHtml);
+        // }
+      } else {
+        console.log('We transform');
+        memoizedTemplates[templateEntryHash] = { htmlPath };
+        createHTMLForTransformation(htmlPath, appHtml);
+      }
+    }
+
+    // Static build
+    await viteBuild({
+      build: {
+        outDir: OUTPUT_DIR,
+        emptyOutDir: true,
+        rollupOptions: {
+          input: createdHTMLFiles
+        }
+      },
+      customLogger: viteCustomLogger,
+      configFile
+    });
+
+    for (const unTransformed of transformationSkippedHTMLFiles) {
+      const relativeToRootHTMLPath = path.relative(
+        ROOT,
+        memoizedTemplates[unTransformed.templateEntryHash].htmlPath
+      );
+      const distHTMLPath = path.join(OUTPUT_DIR, relativeToRootHTMLPath);
+      const templatePage = fs.readFileSync(distHTMLPath, 'utf-8');
+      const cssLinks = Array.from(templatePage.matchAll(CSS_FETCH_REGEX))
+        .map((linkMatch) => linkMatch[0])
+        .join('\n');
+      const jsLinks = Array.from(templatePage.matchAll(JS_FETCH_REGEX))
+        .map((linkMatch) => linkMatch[0])
+        .join('\n');
+      const htmlWithCSS = addCSSToHead(
+        unTransformed.appHtml.replace(CSS_FETCH_REGEX, ''),
+        cssLinks
+      );
+      const htmlWithCSSAndJS = addJStoBodyEnd(
+        htmlWithCSS.replace(JS_FETCH_REGEX, ''),
+        jsLinks
+      );
+      fs.writeFileSync(
+        path.join(OUTPUT_DIR, path.relative(ROOT, unTransformed.htmlPath)),
+        htmlWithCSSAndJS
+      );
+      log(
+        `Created ${path.relative(
+          ROOT,
+          unTransformed.htmlPath
+        )} without transformations`,
+        'p1'
+      );
+    }
+    // We can then loop over untransformed files, match them with their transformed URLs using memoHash
+    // Then remove the existing Link and script URLs from them and add new URLs fetched from template
+  } finally {
+    // CLEANUP
+    for (const HTML_FILE of createdHTMLFiles) {
+      fs.unlinkSync(HTML_FILE);
+    }
+
+    // remove directories
+    for (const newDir of createdDirectories) {
+      fs.rmdirSync(newDir);
+    }
+
+    log(
+      `✨ Site Generated ✨ \n\n${bold('npx serve dist')} to run static server`
+    );
   }
-
-  // remove directories
-  for (const newDir of createdDirectories) {
-    fs.rmdirSync(newDir);
-  }
-
-  log(
-    `✨ Site Generated ✨ \n\n${bold('npx serve dist')} to run static server`
-  );
 }
 
 export default generate;

--- a/packages/abell/src/cli/generate.ts
+++ b/packages/abell/src/cli/generate.ts
@@ -34,7 +34,13 @@ async function generate(): Promise<void> {
       ssr: true,
       rollupOptions: {
         input: SOURCE_ENTRY_BUILD_PATH,
-        external: ['abell']
+        external: ['abell'],
+        onLog: (level, logObj) => {
+          // Ignoring unused abell block warning
+          if (level === 'warn' && logObj.code !== 'UNUSED_EXTERNAL_IMPORT') {
+            log(logObj.message, 'p1');
+          }
+        }
       },
       ssrManifest: true,
       ...viteConfigObj.abell?.serverBuild

--- a/packages/abell/src/cli/generate.ts
+++ b/packages/abell/src/cli/generate.ts
@@ -82,7 +82,6 @@ async function generate(): Promise<void> {
   const transformationSkippedHTMLFiles = [];
   const createdDirectories: string[] = [];
   let importTemplatesMemo: Record<string, { htmlPath: string }> = {};
-  // @TODO: create a flag in abell config to set this to false in case some bug shows up
   const shouldOptimizeTransformations =
     viteConfigObj.abell?.optimizedTransformations ?? true;
 

--- a/packages/abell/src/type-utils.ts
+++ b/packages/abell/src/type-utils.ts
@@ -43,6 +43,20 @@ export type AbellOptions = {
    * ```
    */
   esbuild?: EsbuildTransformOptions;
+
+  /**
+   * Abell uses import hashing to avoid transforming repeated layouts through vite.
+   * It instead copy pastes the import URLs from earlier transformed page.
+   *
+   * Checkout description of this issue to know more https://github.com/abelljs/abell/pull/161#issue-1906511077
+   *
+   * This is set to true by default and in most cases it should work.
+   * This flag is for scenarios where you face some bug due to transformation skips
+   * or when you know what you're doing and want to transform every HTML route through Vite
+   *
+   * @default true
+   */
+  optimizedTransformations?: boolean;
   /**
    * Just like "build" option in Vite. Except this only applies on intermediate server build that is created.
    *

--- a/packages/abell/src/utils/import-hashing.ts
+++ b/packages/abell/src/utils/import-hashing.ts
@@ -1,0 +1,75 @@
+/**
+ * But hey what is import hashing?
+ *
+ * Checkout PR description of https://github.com/abelljs/abell/pull/161#issue-1906511077 for more info
+ *
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { generateHashFromPath } from '../vite-plugin-abell/compiler/scope-css/generate-hash.js';
+
+export const CSS_FETCH_REGEX = /<link.*?href="(.*?)".*?\/?>/g;
+export const JS_FETCH_REGEX = /<script.*?src="(.*?)".*?>[ \n]*?<\/script>/g;
+
+export const getCSSLinks = (templatePage: string): string => {
+  return Array.from(templatePage.matchAll(CSS_FETCH_REGEX))
+    .map((linkMatch) => linkMatch[0])
+    .join('\n');
+};
+
+export const getJSLinks = (templatePage: string): string => {
+  return Array.from(templatePage.matchAll(JS_FETCH_REGEX))
+    .map((linkMatch) => linkMatch[0])
+    .join('\n');
+};
+
+const importTemplatesOutContentMemo: Record<string, string> = {};
+
+/**
+ * Returns the previously transformed page.
+ *
+ * We can copy paste imports from this to our new pages
+ */
+export const getImportTemplatePage = ({
+  ROOT,
+  OUTPUT_DIR,
+  importTemplatesMemo,
+  importsHash
+}: {
+  ROOT: string;
+  OUTPUT_DIR: string;
+  importTemplatesMemo: Record<string, { htmlPath: string }>;
+  importsHash: string;
+}) => {
+  const relativeToRootHTMLPath = path.relative(
+    ROOT,
+    importTemplatesMemo[importsHash].htmlPath
+  );
+  const distHTMLPath = path.join(OUTPUT_DIR, relativeToRootHTMLPath);
+  if (importTemplatesOutContentMemo[distHTMLPath]) {
+    return importTemplatesOutContentMemo[distHTMLPath];
+  }
+
+  const templatePage = fs.readFileSync(distHTMLPath, 'utf-8');
+  if (Object.keys(importTemplatesOutContentMemo).length < 100) {
+    importTemplatesOutContentMemo[distHTMLPath] = templatePage;
+  }
+  return templatePage;
+};
+
+export const getImportsHash = (
+  appHtml: string
+): {
+  importsStringDump: string;
+  importsHash: string;
+} => {
+  // This is dump of all JS and CSS links from page. This (after hashing to smaller string) becomes our unique identifier for import patterns
+  const importsStringDump = getCSSLinks(appHtml) + getJSLinks(appHtml);
+  const importsHash = generateHashFromPath(importsStringDump);
+
+  return {
+    importsStringDump,
+    importsHash
+  };
+};

--- a/packages/abell/src/utils/internal-utils.ts
+++ b/packages/abell/src/utils/internal-utils.ts
@@ -378,6 +378,24 @@ export async function clearCache(): Promise<void> {
   }
 }
 
+export const addCSSToHead = (htmlContent: string, cssLinks: string): string => {
+  if (htmlContent.includes('</head>')) {
+    return htmlContent.replace('</head>', cssLinks + '</head>');
+  }
+  return cssLinks + htmlContent;
+};
+
+export const addJStoBodyEnd = (
+  htmlContent: string,
+  jsLinks: string
+): string => {
+  if (htmlContent.includes('</body>')) {
+    return htmlContent.replace('</body>', jsLinks + '</body>');
+  }
+
+  return htmlContent + jsLinks;
+};
+
 /**
  * Evaluates the abell block.
  *

--- a/packages/abell/src/utils/logger.ts
+++ b/packages/abell/src/utils/logger.ts
@@ -1,10 +1,13 @@
 import { createLogger } from 'vite';
+import { AbellViteConfig } from '../type-utils.js';
 
 const reset = '\u001b[0m';
 const blueColorCode = '\u001b[34m';
 export const bold = (message: string): string => `\u001b[1m${message}${reset}`;
-const blue = (message: string) => `${blueColorCode}${message}${reset}`;
-const grey = (message: string) => `\u001b[90m${message}${reset}`;
+export const blue = (message: string) => `${blueColorCode}${message}${reset}`;
+export const grey = (message: string) => `\u001b[90m${message}${reset}`;
+export const dim = (message: string) => `\u001b[2m${message}${reset}`;
+export const secret = (message: string) => `\u001b[22m${message}${reset}`;
 const underline = (message: string) => `\u001b[4m${message}${reset}`;
 
 export const boldUnderline = (message: string): string =>
@@ -20,20 +23,31 @@ export const viteCustomLogger = createLogger('info', {
 const loggerInfo = viteCustomLogger.info;
 viteCustomLogger.info = (msg, options) => {
   if (msg.includes('building SSR bundle')) return;
+  if (msg.includes('built in')) return;
 
   // Replacing colors in terminal with blue color for Abell theme
   loggerInfo(
-    msg.replace(/\u001b\[3[0-6]m/g, blueColorCode).replaceAll('vite', 'Vite'),
+    reset +
+      msg.replace(/\u001b\[3[0-6]m/g, blueColorCode).replaceAll('vite', 'Vite'),
     options
   );
 };
 
-export const log = (message: string, importance: 'p0' | 'p1' = 'p0'): void => {
-  if (importance === 'p1') {
-    console.log(blue('‣'), grey(message));
-  } else {
-    console.log('');
-    console.log(PREFIX, message);
-    console.log('');
+export const log = (
+  message: string,
+  importance: 'p0' | 'p1' = 'p0',
+  {
+    icon = '‣',
+    logLevel = 'info'
+  }: { icon?: string; logLevel?: AbellViteConfig['logLevel'] | 'debug' } = {}
+): void => {
+  if (logLevel === 'info' || logLevel === 'debug') {
+    if (importance === 'p1') {
+      console.log(reset, blue(icon), grey(message));
+    } else {
+      console.log('');
+      console.log(PREFIX, message);
+      console.log('');
+    }
   }
 };

--- a/playground/basic/basic.spec.ts
+++ b/playground/basic/basic.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { describe, test, expect, beforeAll } from 'vitest';
-import { run, getDocument } from './test-utils';
+import { run, getDocument } from '../test-utils';
 
 describe('basic', () => {
   beforeAll(async () => {

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -14,17 +14,25 @@ const windowsifyCommand = (command: string): string => {
 };
 
 let dir: string = __dirname;
-export async function run(cwd: string): Promise<void> {
+export async function run(
+  cwd: string,
+  stdio: 'pipe' | 'inherit' = 'pipe'
+): Promise<string> {
   dir = cwd;
   return new Promise((resolve, reject) => {
     const child = spawn(windowsifyCommand('pnpm'), ['generate'], {
       cwd,
-      stdio: 'inherit'
+      stdio
+    });
+    let terminalOutput = '';
+
+    child.stdout?.on('data', (data) => {
+      terminalOutput += data;
     });
 
     child.on('close', (code: number) => {
       if (code === 0) {
-        resolve();
+        resolve(terminalOutput);
       } else {
         // eslint-disable-next-line prefer-promise-reject-errors
         reject();

--- a/playground/transformations-count/about.abell
+++ b/playground/transformations-count/about.abell
@@ -1,0 +1,5 @@
+<html>
+<body>
+  Hello from About Page
+</body>
+</html>

--- a/playground/transformations-count/about.abell
+++ b/playground/transformations-count/about.abell
@@ -6,6 +6,8 @@
 
 <body>
   Hello from About Page
+  <script src="./entry.ts" type="module"></script>
 </body>
+
 
 </html>

--- a/playground/transformations-count/about.abell
+++ b/playground/transformations-count/about.abell
@@ -1,5 +1,11 @@
 <html>
+
+<head>
+  <link rel="stylesheet" href="./css/global.css" />
+</head>
+
 <body>
   Hello from About Page
 </body>
+
 </html>

--- a/playground/transformations-count/css/global.css
+++ b/playground/transformations-count/css/global.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0px;
+}

--- a/playground/transformations-count/entry.build.ts
+++ b/playground/transformations-count/entry.build.ts
@@ -1,0 +1,23 @@
+/// <reference types="abell/types" />
+
+import { Route } from 'abell';
+import index from './index.abell';
+import about from './about.abell';
+import { date } from './something.js';
+
+export const makeRoutes = (): Route[] => {
+  return [
+    {
+      path: '/',
+      render: index
+    },
+    {
+      path: '/about-1',
+      render: () => about({ date })
+    },
+    {
+      path: '/about-2',
+      render: () => about({ date })
+    }
+  ];
+};

--- a/playground/transformations-count/entry.build.ts
+++ b/playground/transformations-count/entry.build.ts
@@ -18,6 +18,10 @@ export const makeRoutes = (): Route[] => {
     {
       path: '/about-2',
       render: () => about({ date })
+    },
+    {
+      path: '/about-3',
+      render: () => about({ date })
     }
   ];
 };

--- a/playground/transformations-count/entry.ts
+++ b/playground/transformations-count/entry.ts
@@ -1,0 +1,1 @@
+console.log('hi');

--- a/playground/transformations-count/index.abell
+++ b/playground/transformations-count/index.abell
@@ -1,0 +1,5 @@
+<html>
+<body>
+  hello from index page
+</body>
+</html>

--- a/playground/transformations-count/index.abell
+++ b/playground/transformations-count/index.abell
@@ -1,5 +1,7 @@
 <html>
+
 <body>
   hello from index page
 </body>
+
 </html>

--- a/playground/transformations-count/package.json
+++ b/playground/transformations-count/package.json
@@ -6,7 +6,9 @@
   "private": "true",
   "scripts": {
     "dev": "abell --version && abell dev",
-    "generate": "abell generate"
+    "generate": "abell generate",
+    "test": "vitest",
+    "test:once": "vitest run"
   },
   "keywords": [],
   "author": "",

--- a/playground/transformations-count/package.json
+++ b/playground/transformations-count/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "custom-routing",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "private": "true",
+  "scripts": {
+    "dev": "abell --version && abell dev",
+    "generate": "abell generate"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "abell": "workspace:*"
+  }
+}

--- a/playground/transformations-count/something.js
+++ b/playground/transformations-count/something.js
@@ -1,0 +1,1 @@
+export const date = new Date().getTime();

--- a/playground/transformations-count/transformation-count.spec.ts
+++ b/playground/transformations-count/transformation-count.spec.ts
@@ -1,0 +1,65 @@
+/* eslint-disable max-len */
+import { describe, test, expect, beforeAll } from 'vitest';
+import { run, getDocument } from '../test-utils';
+
+describe('basic', () => {
+  let terminalOutput = '';
+  beforeAll(async () => {
+    terminalOutput = await run(__dirname, 'pipe');
+  });
+
+  test('should have 2 transformation for this project', () => {
+    expect(terminalOutput).toContain(
+      'Created 2 files with optimized transformations'
+    );
+  });
+
+  test('index.html', () => {
+    const container = getDocument('index.html');
+    expect(container.querySelector('html')?.outerHTML).toMatchInlineSnapshot(`
+      "<html><head></head><body>
+        hello from index page
+
+
+      </body></html>"
+    `);
+  });
+
+  // The transformed file
+  test('about-1.html', () => {
+    const container = getDocument('about-1.html');
+    expect(container.querySelector('html')?.outerHTML).toMatchInlineSnapshot(`
+      "<html><head>
+        
+        <script type=\\"module\\" crossorigin=\\"\\" src=\\"/assets/about-1-302b396f.js\\"></script>
+        <link rel=\\"stylesheet\\" href=\\"/assets/about-1-6d606818.css\\">
+      </head>
+
+      <body>
+        Hello from About Page
+        
+
+
+
+      </body></html>"
+    `);
+  });
+
+  // The non-transformed file
+  test('about-2.html', () => {
+    const container = getDocument('about-2.html');
+    expect(container.querySelector('html')?.outerHTML).toMatchInlineSnapshot(`
+      "<html><head>
+        
+      <link rel=\\"stylesheet\\" href=\\"/assets/about-1-6d606818.css\\"></head>
+
+      <body>
+        Hello from About Page
+        
+      <script type=\\"module\\" crossorigin=\\"\\" src=\\"/assets/about-1-302b396f.js\\"></script>
+
+
+      </body></html>"
+    `);
+  });
+});


### PR DESCRIPTION
## Description

PR to reduce the number of transformations

## What is transformation in this context?

Here we are talking about passing HTML file to bundler (vite in this case) so that bundler can fix the asset URLs (and few other things)

```html
<!-- What you write in code -->
<html>
<head>
  <link rel="stylesheet" href="./global.css" />
  <script src="./entry.ts" type="module"></script>
</head>
<body>
  <h1>Hello</h1>
</body>

<!-- After Vite Transformation -->
<html>
<head>
  <link rel="stylesheet" href="/assets/global-hsadsk23.css" />
  <script src="/assets/entry-kshjfdfd123.js" type="module"></script>
</head>
<body>
  <h1>Hello</h1>
</body>
```

## Why number of transformations were more in Abell?

You might have seen a `layout: docs.ejs` kind of setting in other static-site-generators which allows them to define which layout the content is using. They can then 

Abell doesn't have "layout" components as such. Every page is just returning HTML in abell. 

This is kind of how the final routing looks to abell (so eventually abell doesn't really know what layout these routes are using. For abell, everything is unique HTML)-
```js
export const makeRoutes = () => {
  return [
    {
      path: '/about-1',
      render: () => `<html><body><b>about 1 html</b></body></html>`
    },
    {
       path: '/about-2',
       render: () => `<html><body><b>about 2 html</b></body></html>`
    }
  ]
}
```

This means, every page has to go through the vite transformation even if the layout of the page is largely similar

## Solution

What we essentially want to figure out is how many pages have same CSS / JS imports. E.g. if we use `docs.abell` which imports `global.css` and `main.ts`, every route using the docs.abell layout will have the same imports.

The purpose of transformation is to transform these imports so if we keep map of all imports that were previously transformed, we don't have to repeat the transformation

### Import Hashing 🚀

We now create a hash out of same imports. So 2 pages importing same set of CSS, and JS files, will have a same hash. This hash is used as a memo key to store information about those imports.

So next time we come across any file with same imports, rather than transforming it through Vite again, we just map its information using import hash and copy paste the transformed CSS / JS urls from earlier file.


## Results
- Skips the transformations for repeated imports
  <img width="300" alt="image" src="https://github.com/abelljs/abell/assets/30949385/7240fc04-abab-483f-950b-c6c58491dde6">
- [Perf Improvements on 4000 markdown files](https://x.com/saurabhdawaree/status/1704821811861508241?s=20)
