### PR TITLE
feat(docs): add why-abell docs

### DIFF
--- a/packages/docs/client/docs.css
+++ b/packages/docs/client/docs.css
@@ -119,10 +119,9 @@ h2:hover a, h3:hover a {
 }
 
 h3 {
-  font-size: 1.5rem;
+  font-size: 1.3rem;
   margin: 0px;
-  padding: 2.5rem 0rem 1rem 0rem;
-
+  margin-bottom: 1rem;
 }
 
 .or {

--- a/packages/docs/client/docs.ts
+++ b/packages/docs/client/docs.ts
@@ -54,8 +54,11 @@ subheadings.forEach((subheading) => {
   const text = subheading.innerText;
 
   const id = text.toLowerCase().replace(/ /g, '-').replace(/[?!&]/g, '');
-  // subheading.id = id;
   subheading.innerHTML = subheading.innerHTML + `<a href="#${id}">#</a>`;
+  if (subheading.tagName === 'H3') {
+    return;
+  }
+
   subMenuLists += `
     <li>
       <a href="#${id}">

--- a/packages/docs/content/syntax-guide.mdx
+++ b/packages/docs/content/syntax-guide.mdx
@@ -91,10 +91,11 @@ Abell has native component support. It allows you to make your HTML, CSS code re
 You can define component starting with `_` to tell abell to not create a page of it in final output. You can also opt-out of this `_` rule (and file-system routing) by using [Custom Routing](/custom-routing).
 
 <div dangerouslySetInnerHTML={{ __html: editor(componentsUsage) }} />
+<br />
 
 ### Passing Props
 
-Whenever you import an `.abell` file, it returns a javascript function that can render the HTML.
+Whenever you import a `.abell` file, it returns a javascript function that can render the HTML.
 
 The first argument you pass to this function can be read from variable `props` in the imported file.
 

--- a/packages/docs/content/why-abell.mdx
+++ b/packages/docs/content/why-abell.mdx
@@ -1,13 +1,58 @@
-import editor from '../components/editor.abell';
-import { noConfigSetup } from '../utils/examples.ts';
-
 # Why Abell
 
-## Overview
+We know there are lots of static-site-generators and you might be wondering how is Abell different from them. This page might help you get that answer.
 
-<div dangerouslySetInnerHTML={{ __html: editor(noConfigSetup) }} />
+## What is Abell?
 
-Abell is a Static-Site-Generator for **building fast websites** while giving **maximum
-flexibility to developers**
+Well... apart from being [a galaxy cluster whose name happened to be available on NPM](https://en.wikipedia.org/wiki/Abell_2029), it is a Static-Site Generator built by [Saurabh](https://saurabhdaware.in) and GitHub Contributors 🫶🏼.
 
-{/* <Editor /> */}
+Abell takes inspirations from several tools in the ecosystem.
+
+To elaborate, Abell is -
+
+- **Low-Level** like Jekyll, Hugo, Hexo and tries to stay closer to HTML for smaller learning curve 🤓
+- **Framework Agnostic** and easily integrates with modern tools like MDX, TypeScript, and client-side frameworks like Astro does 🤗
+- **Vite Powered** which allows it to integrate with these modern tools by just using Vite plugins 🫡
+- **Static-Site-Generator** to help you build blogs, documentation sites, portfolios, landing pages, and pretty much anything static.
+
+## Backstory
+
+"Low-Level" is subjective. Its easier to understand API decisions of Abell by understanding it's backstory and few messups 🙈
+
+### Abell Zero
+
+Abell was started in April 2020 by [Saurabh](https://twitter.com/saurabhdawaree). It was primarily inspired from Jekyll, Hugo, and Hexo but with a template engine that new JavaScript developers would find simpler (Jekyll and Hugo were using Ruby and GO and Hexo was using ejs but ejs had its own learing curve).
+
+Few people like [pantharshit00](https://github.com/pantharshit00), and [prafulla-codes](https://github.com/prafulla-codes), and multiple other GitHub contributors helped along the way to help build abell-renderer (A lot of these contributions continue to work in Abell v1).
+
+So far it sounds great right? Except it didn't go as plan.
+
+Saurabh wrote a detailed blog on <a target="_blank" href="https://blog.saurabhdaware.in/things-that-went-wrong-with-abell-v0">What Went Wrong with Abell v0</a>. The TLDR from that blog is-
+
+So New Features === New Syntax === Higher Learning Curve (bummer 😢)
+
+Every feature like component, JSX, framework integrations, Plugins, etc required us to create new syntax which added to learning curve and eventually Abell v0 became the thing that it tried to fix. A template engine of high learning curve.
+
+<br />
+
+### Abell One
+
+Alright, last thing didn't go well. Attempt 2 of fixing the same issues.
+
+So how do you add features but not add learning curve?
+
+Hint: You make things integratable and let people come with their own comfort tools!!
+
+There is fundamental problem with traditional template engines though. They compile to HTML which bundlers strugle to understand. Bundlers love JavaScript so a lot of integrations like TypeScript, MDX, Framework Components happen over JavaScript part.
+
+This has also been an issue in existing traditional template-engine-based static-site-generators where a lot of them either struggled to integrate with modern tools or could not integrate at all.
+
+There was 1 template engine (kinda?) that integrated really well with ecosystem! That was Vue's SFC.
+
+Vue (and other client-side frameworks) for years used a webpack plugin to compile `.vue` files to JavaScript which integrated well with ecosystem. What if we go with that approach but make it focus on build-time? That's when we started exploring bundlers.
+
+Around this time, Astro was released and it used Vite as a bundler which validated the idea that something like this can be built using Vite and became the reason why Saurabh chose Vite over other bundlers.
+
+Abell became a low-level tool like Jekyll, Hugo which stays closer to Vanilla HTML while integrating into the modern JS ecosystem like Astro, and other client-side frameworks.
+
+Eventually Abell also expanded the definition of "low-level" by making decisions like `makeRoutes` API which gives you a low-level access to the routing and final HTML itself.

--- a/packages/docs/entry.build.ts
+++ b/packages/docs/entry.build.ts
@@ -7,6 +7,7 @@ import webcontainer from './webcontainer.abell';
 import docs from './docs.abell';
 
 // Content
+import whyAbell from './content/why-abell.mdx';
 import gettingStartedContent from './content/getting-started.mdx';
 import syntaxGuide from './content/syntax-guide.mdx';
 import customRouting from './content/custom-routing.mdx';
@@ -15,6 +16,11 @@ import { getContributors } from './utils/getContributors.js';
 
 // Docs Routes
 const docsPaths = [
+  {
+    path: '/docs/why-abell',
+    title: 'Why Abell',
+    content: whyAbell
+  },
   {
     path: '/docs/getting-started',
     title: 'Getting Started',


### PR DESCRIPTION
Add temporary why abell docs.

Might rephrase few things eventually but wanted to have some why-abell docs before release.