### PR TITLE
Fix: Additional Padding in Algolia Search 

### DIFF
--- a/packages/docs/client/docs.css
+++ b/packages/docs/client/docs.css
@@ -269,6 +269,9 @@ button.hamburger-menu .icon {
 .DocSearch-Container {
   backdrop-filter: blur(3px) !important;
 }
+.DocSearch-Hits{
+  padding: 0;
+}
 
 @media (max-width: 768px) {
   .header-placeholder {


### PR DESCRIPTION
<!---
To check the checkbox add 'x' inside brackets
E.g:
- [x] Feature
-->

## What type of PR is this?

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

<!-- Describe what your PR does and steps to check it -->

## Description
Fixes: https://github.com/abelljs/abell/issues/169
Padding inside the algolia search container is getting overwritten by Abell css, so Added explicit `padding:0` for the search container.
<span>
<img width="300" alt="Screenshot 2023-10-27 at 4 49 40 PM" src="https://github.com/abelljs/abell/assets/54790263/470c1a63-0cff-455e-808f-d2c846eaf3b2">
<img width="300" alt="Screenshot 2023-10-27 at 4 49 50 PM" src="https://github.com/abelljs/abell/assets/54790263/206878c2-3127-4a26-8090-f4e0d15cf242">
</span>


## Added unit tests?

- [ ] No, I want help in writing tests.
- [ ] No, I want someone else to write tests.
- [x] No, The addition does not need tests.
- [ ] Yes

## [optional] Random GIF to +1 someone's day
<img width="300" alt="gif" src="https://media.giphy.com/media/13FrpeVH09Zrb2/giphy.gif">
